### PR TITLE
Notes on autoformat whitespace issue.

### DIFF
--- a/notes.html
+++ b/notes.html
@@ -37,18 +37,33 @@
 ;; answer 15 min
 ;; action 25 min
 ;; Conclusion 5 min
+note that I used two SPACES after the * to make the invisible heading for the non-title title slide.
 </p>
 
 </aside>
 
+<aside class="notes">
+<p>
+aha! about the `PROPERTIES` below setting <span class="underline">all</span> backgrounds vs. just this one:
+if the extra space in the *_ title is removed (which annoyingly happens automatically (autoformat?)
+then the value is extended to ALL slides, but if the second space remains and the '  ' is treated as the header title,
+then the custom background applies only to the slide.
+check that there's a litte dot instead of an asterisk&#x2026;
+</p>
+<ul>
+<li>autoformat is the culprit!  use SPC - t - W to disable auto-whitespace stripping</li>
+
+</ul>
+
+</aside>
 <section>
-<section id="slide-org861496d" data-background="file:resources/images/title-screen_2017-01-16_16-18-34.png" data-background-size="100%">
-<h2 id="org861496d"></h2>
+<section id="slide-orgfc0376c" data-background="file:resources/images/title-screen_2017-01-16_16-18-34.png" data-background-size="100%">
+<h2 id="orgfc0376c"></h2>
 </section>
 </section>
 <section>
-<section id="slide-orgd5c04eb">
-<h2 id="orgd5c04eb"><span class="todo TODO">TODO</span> Introduction</h2>
+<section id="slide-orgf1e9354">
+<h2 id="orgf1e9354"><span class="todo TODO">TODO</span> Introduction</h2>
 <p>
 TODO Add why me?  bit about foot in mouth, followed by learning about learning for MCSE, but was still hungry to know how computer worked.
 </p>
@@ -93,30 +108,30 @@ If I discover that I value learning greatly, how can I live a life consistent wi
 </aside>
 
 </section>
-<section id="slide-org5e6d10d">
-<h3 id="org5e6d10d">Talk Outline</h3>
-<div class="outline-text-3" id="text-org5e6d10d">
+<section id="slide-org0d8d76b">
+<h3 id="org0d8d76b">Talk Outline</h3>
+<div class="outline-text-3" id="text-org0d8d76b">
 </div></section>
-<section id="slide-orgd8f273f">
-<h4 id="orgd8f273f">What is the question?</h4>
+<section id="slide-org6b407af">
+<h4 id="org6b407af">What is the question?</h4>
 <p>
 How much do I value learning?
 </p>
 </section>
-<section id="slide-orgcd655f0">
-<h4 id="orgcd655f0">How can I know the answer?</h4>
+<section id="slide-org41ee4d6">
+<h4 id="org41ee4d6">How can I know the answer?</h4>
 <p>
 How can I measure the value I place on learning?
 </p>
 </section>
-<section id="slide-org685ff78">
-<h4 id="org685ff78">Now I know. What do I do?</h4>
+<section id="slide-org953ff39">
+<h4 id="org953ff39">Now I know. What do I do?</h4>
 <p>
 What actions are consistent with this value?
 </p>
 </section>
-<section id="slide-org6db21aa">
-<h4 id="org6db21aa">Simplest possible outline</h4>
+<section id="slide-org051e3bc">
+<h4 id="org051e3bc">Simplest possible outline</h4>
 <p>
 -Question
 -Answer
@@ -130,8 +145,8 @@ That might still feel like a earful, so let's milk the outline down to its simpl
 </aside>
 
 </section>
-<section id="slide-org93c95ce">
-<h3 id="org93c95ce">Learning, the invisible value</h3>
+<section id="slide-org66dbe00">
+<h3 id="org66dbe00">Learning, the invisible value</h3>
 <blockquote nil>
 <p>
 In all affairs it's a healthy thing now and then to hang a question mark on the things you have long taken for granted. &#x2013; Bertrand Russell
@@ -162,8 +177,8 @@ At the very least, attempting to answer this question is in accord with the age 
 </aside>
 
 </section>
-<section id="slide-org18218c4">
-<h3 id="org18218c4">Brain, the invisible organ</h3>
+<section id="slide-org19a56fd">
+<h3 id="org19a56fd">Brain, the invisible organ</h3>
 <aside class="notes">
 <p>
 While learning may be the invisible value, the brain is the invisible organ. At least that's the excuse I use to explain why, in my youth, I was <b>not</b> very interested in the brain, or how I could use it to improve my life.
@@ -194,14 +209,14 @@ Maybe the brain just needs better PR. This talk hopes to remedy that. No let's p
 </section>
 </section>
 <section>
-<section id="slide-org0f028c3">
-<h2 id="org0f028c3">What is the question?</h2>
+<section id="slide-org012a5b6">
+<h2 id="org012a5b6">What is the question?</h2>
 <p>
 How much do I value learning?
 </p>
 </section>
-<section id="slide-org5635a5d">
-<h3 id="org5635a5d">Understanding the question</h3>
+<section id="slide-org769f9f4">
+<h3 id="org769f9f4">Understanding the question</h3>
 <p>
 How much do I value learning?
 </p>
@@ -213,8 +228,8 @@ Let's make sure we understand the question by looking at the meaning and history
 </aside>
 
 </section>
-<section id="slide-orga012773">
-<h4 id="orga012773">Value defined</h4>
+<section id="slide-orgb8a8bec">
+<h4 id="orgb8a8bec">Value defined</h4>
 <p>
 definition: 
 (merriam-webster.com)
@@ -250,8 +265,8 @@ If you're a Game of Thrones fan, you've likely noticed how similar <i>valēre</i
 </aside>
 
 </section>
-<section id="slide-org74f8e75">
-<h4 id="org74f8e75">Learning defined</h4>
+<section id="slide-org33db400">
+<h4 id="org33db400">Learning defined</h4>
 <p>
 definition:
 (learnersdictionary.com)
@@ -290,7 +305,7 @@ The latin meaning has become my favorite way to think about learning &#x2013; pl
 
 </aside>
 
-<ul class="org-ul"><li><a id="org0d80aea"></a>Learn as synonym for Teach<br  /><p>
+<ul class="org-ul"><li><a id="org323e95e"></a>Learn as synonym for Teach<br  /><p>
 (merriam-webster.com)
 Master blacksmiths learned their apprentices in the craft of sword forging.
 </p>
@@ -306,12 +321,12 @@ Today this alternative meaning is relegated to speech, because it's <b>not</b> c
 </aside></li></ul>
 
 </section>
-<section id="slide-org3cbf8f4">
-<h4 id="org3cbf8f4">The history of learning</h4>
-<div class="outline-text-4" id="text-org3cbf8f4">
-</div><ul class="org-ul"><li><a id="orged66c3b"></a>Evolution! We are the very best learners in all of history.<br  /><ul class="org-ul"><li><a id="org5d9469f"></a><span class="todo TODO">TODO</span> Rich Hicky quote - from my goodnotes<br  /></li></ul></li>
-<li><a id="org3f3eed8"></a>Socrates<br  /><ul class="org-ul"><li><a id="org58b7ba8"></a><span class="todo TODO">TODO</span> Socratic dialogue: add quote about "make them think" --<br  /></li></ul></li>
-<li><a id="orgcfc1877"></a>Small Gap (Picture of Grand Canyon)<br  /><div class="figure">
+<section id="slide-org57b9d14">
+<h4 id="org57b9d14">The history of learning</h4>
+<div class="outline-text-4" id="text-org57b9d14">
+</div><ul class="org-ul"><li><a id="org8cf8239"></a>Evolution! We are the very best learners in all of history.<br  /><ul class="org-ul"><li><a id="org99e1099"></a><span class="todo TODO">TODO</span> Rich Hicky quote - from my goodnotes<br  /></li></ul></li>
+<li><a id="org3d5c6a6"></a>Socrates<br  /><ul class="org-ul"><li><a id="orgb910dde"></a><span class="todo TODO">TODO</span> Socratic dialogue: add quote about "make them think" --<br  /></li></ul></li>
+<li><a id="orgd191b59"></a>Small Gap (Picture of Grand Canyon)<br  /><div class="figure">
 <p><img src="resources/images/What is the history of SALT?/grand-canyon-filled with-fog-todd-diemer_2017-01-13_09-53-33.jpg" alt="grand-canyon-filled with-fog-todd-diemer_2017-01-13_09-53-33.jpg" />
 </p>
 </div>
@@ -321,24 +336,24 @@ The 1926, pioneering paper by Eduard C. Lindeman's, <i>The Meaning of Adult Educ
 </p></li></ul>
 
 </section>
-<section id="slide-org03f68bd">
-<h4 id="org03f68bd">Two modes of learning</h4>
-<div class="outline-text-4" id="text-org03f68bd">
-</div><ul class="org-ul"><li><a id="org6615953"></a>Inside Out<br  /></li>
+<section id="slide-org00e9c83">
+<h4 id="org00e9c83">Two modes of learning</h4>
+<div class="outline-text-4" id="text-org00e9c83">
+</div><ul class="org-ul"><li><a id="orgd06f827"></a>Inside Out<br  /></li>
 
-<li><a id="org0a085b5"></a>Outside In<br  /></li></ul>
+<li><a id="org6a59a06"></a>Outside In<br  /></li></ul>
 
 </section>
 </section>
 <section>
-<section id="slide-org745c2c5">
-<h2 id="org745c2c5">How can I know the answer?</h2>
+<section id="slide-org58ca1b1">
+<h2 id="org58ca1b1">How can I know the answer?</h2>
 <p>
 How can I measure how much value I place on learning?
 </p>
 </section>
-<section id="slide-org9eda5e1">
-<h3 id="org9eda5e1">Answers aren't everything</h3>
+<section id="slide-org452e1a0">
+<h3 id="org452e1a0">Answers aren't everything</h3>
 <p>
 Questions are powerful on their own.
 </p>
@@ -353,8 +368,8 @@ This question could have been tackled any number of ways. I stumbled upon this o
 
 </aside>
 </section>
-<section id="slide-orgd9c0112">
-<h3 id="orgd9c0112">How would you go about it?</h3>
+<section id="slide-orgabe8686">
+<h3 id="orgabe8686">How would you go about it?</h3>
 <aside class="notes">
 <p>
 Give the audience a chance to grapple with the question
@@ -362,194 +377,194 @@ Give the audience a chance to grapple with the question
 
 </aside>
 </section>
-<section id="slide-orge155d13">
-<h3 id="orge155d13">The instrumental value of my learning</h3>
-<div class="outline-text-3" id="text-orge155d13">
+<section id="slide-org47dbaca">
+<h3 id="org47dbaca">The instrumental value of my learning</h3>
+<div class="outline-text-3" id="text-org47dbaca">
 </div></section>
-<section id="slide-orgf6a83a5">
-<h4 id="orgf6a83a5">Topsy turvy world view of my childhood - stars on the ceiling</h4>
-<div class="outline-text-4" id="text-orgf6a83a5">
-</div><ul class="org-ul"><li><a id="orgb5f5775"></a>Sunset story<br  /></li></ul>
+<section id="slide-org75e759c">
+<h4 id="org75e759c">Topsy turvy world view of my childhood - stars on the ceiling</h4>
+<div class="outline-text-4" id="text-org75e759c">
+</div><ul class="org-ul"><li><a id="org39c784f"></a>Sunset story<br  /></li></ul>
 </section>
-<section id="slide-orgd1b7a6b">
-<h4 id="orgd1b7a6b">Child like sense of curiosity, awe and wonder - Nature/Even from a magazine Wow!, Pepper/Insects/Thanksgiving</h4>
-<div class="outline-text-4" id="text-orgd1b7a6b">
-</div><ul class="org-ul"><li><a id="org1bb8bab"></a>Exceptions! <a href="https://www.theatlantic.com/health/archive/2016/09/is-awe-really-good-for-you/501086/">https://www.theatlantic.com/health/archive/2016/09/is-awe-really-good-for-you/501086/</a><br  /></li></ul>
+<section id="slide-orgf32665a">
+<h4 id="orgf32665a">Child like sense of curiosity, awe and wonder - Nature/Even from a magazine Wow!, Pepper/Insects/Thanksgiving</h4>
+<div class="outline-text-4" id="text-orgf32665a">
+</div><ul class="org-ul"><li><a id="org50a6993"></a>Exceptions! <a href="https://www.theatlantic.com/health/archive/2016/09/is-awe-really-good-for-you/501086/">https://www.theatlantic.com/health/archive/2016/09/is-awe-really-good-for-you/501086/</a><br  /></li></ul>
 </section>
-<section id="slide-orgc0c9874">
-<h4 id="orgc0c9874">Philosophy - Stoics (Tim Ferris calls ideal personal operating system)</h4>
+<section id="slide-orgc5caf5f">
+<h4 id="orgc5caf5f">Philosophy - Stoics (Tim Ferris calls ideal personal operating system)</h4>
 </section>
-<section id="slide-org13dea48">
-<h4 id="org13dea48">Time - First, Second aha!</h4>
+<section id="slide-orge00e59c">
+<h4 id="orge00e59c">Time - First, Second aha!</h4>
 </section>
-<section id="slide-org737fc4f">
-<h4 id="org737fc4f">Long Wave - Not just investing, but timing things, like education</h4>
-<div class="outline-text-4" id="text-org737fc4f">
-</div><ul class="org-ul"><li><a id="orgc952326"></a>Sold my house in July of 2007.<br  /></li></ul>
+<section id="slide-org29a7b7c">
+<h4 id="org29a7b7c">Long Wave - Not just investing, but timing things, like education</h4>
+<div class="outline-text-4" id="text-org29a7b7c">
+</div><ul class="org-ul"><li><a id="org7501c30"></a>Sold my house in July of 2007.<br  /></li></ul>
 </section>
-<section id="slide-orgd9815d3">
-<h4 id="orgd9815d3">Clojure</h4>
-<div class="outline-text-4" id="text-orgd9815d3">
-</div><ul class="org-ul"><li><a id="org412f941"></a>Why Clojure - React Native holism etc.<br  /></li></ul>
+<section id="slide-orgb98e941">
+<h4 id="orgb98e941">Clojure</h4>
+<div class="outline-text-4" id="text-orgb98e941">
+</div><ul class="org-ul"><li><a id="orgc2c3a74"></a>Why Clojure - React Native holism etc.<br  /></li></ul>
 </section>
-<section id="slide-org5961aa1">
-<h4 id="org5961aa1">Family, friends and human relationships</h4>
-<div class="outline-text-4" id="text-org5961aa1">
-</div><ul class="org-ul"><li><a id="org1f522fa"></a>Vipassana Mediation - Understanding the mind/body commection<br  /><ul class="org-ul"><li><a id="org3990c09"></a>Anger and emotional turmoil is no respecter of religion or philosophy<br  /></li></ul></li></ul>
+<section id="slide-org9db6e45">
+<h4 id="org9db6e45">Family, friends and human relationships</h4>
+<div class="outline-text-4" id="text-org9db6e45">
+</div><ul class="org-ul"><li><a id="org9131756"></a>Vipassana Mediation - Understanding the mind/body commection<br  /><ul class="org-ul"><li><a id="orgda06f35"></a>Anger and emotional turmoil is no respecter of religion or philosophy<br  /></li></ul></li></ul>
 </section>
-<section id="slide-orgd78dfcb">
-<h4 id="orgd78dfcb">Co-Intelligence &amp; Futurism</h4>
-<div class="outline-text-4" id="text-orgd78dfcb">
-</div><ul class="org-ul"><li><a id="org8d6fbce"></a><span class="todo TODO">TODO</span> <a href="https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/">https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/</a> find quote<br  /></li></ul>
+<section id="slide-orgef77ec1">
+<h4 id="orgef77ec1">Co-Intelligence &amp; Futurism</h4>
+<div class="outline-text-4" id="text-orgef77ec1">
+</div><ul class="org-ul"><li><a id="org749d458"></a><span class="todo TODO">TODO</span> <a href="https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/">https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/</a> find quote<br  /></li></ul>
 </section>
-<section id="slide-orgc20890e">
-<h4 id="orgc20890e">Learning from failure yields long term success</h4>
+<section id="slide-org8abaf20">
+<h4 id="org8abaf20">Learning from failure yields long term success</h4>
 <p>
 Therefore learning, not winning is the greater value.
 </p>
 </section>
-<section id="slide-orge4ba140">
-<h4 id="orge4ba140">Learning is Adapting</h4>
+<section id="slide-orgf5102a2">
+<h4 id="orgf5102a2">Learning is Adapting</h4>
 <p>
 And adapting is human. (Tie in Clojure connection)
 </p>
 </section>
 </section>
 <section>
-<section id="slide-org559c16a">
-<h2 id="org559c16a">Now I know. What do I do?</h2>
+<section id="slide-org205d17e">
+<h2 id="org205d17e">Now I know. What do I do?</h2>
 <p>
 What actions are consistent with this value?
 </p>
 </section>
-<section id="slide-orgd4ac63b">
-<h3 id="orgd4ac63b">If we value learning, why not get better at it, instead of dribbling the ball incessantly.</h3>
+<section id="slide-orgc67b5d6">
+<h3 id="orgc67b5d6">If we value learning, why not get better at it, instead of dribbling the ball incessantly.</h3>
 <p>
  ** What if there was a subject you could study which would improve your ability to learn and master any other subject?
 There just might be&#x2026;
 </p>
 </section>
-<section id="slide-orgdba0255">
-<h4 id="orgdba0255">The science of learning.</h4>
+<section id="slide-orgd295abc">
+<h4 id="orgd295abc">The science of learning.</h4>
 
 <div class="figure">
 <p><img src="resources/images/Opening &amp; Overview/illustration-of-drawing-skill-improvement-in-5-days_2017-01-12_09-19-11.png" alt="illustration-of-drawing-skill-improvement-in-5-days_2017-01-12_09-19-11.png" class="fragment appear" />
 </p>
 </div>
 </section>
-<section id="slide-orgf8dd3d9">
-<h4 id="orgf8dd3d9">Learning How to Learn</h4>
+<section id="slide-orgf28464b">
+<h4 id="orgf28464b">Learning How to Learn</h4>
 </section>
-<section id="slide-org594df52">
-<h4 id="org594df52">Space Repetition etc.</h4>
-</section>
-</section>
-<section>
-<section id="slide-org20a85fc">
-<h2 id="org20a85fc">What is the difference between Learning and Education</h2>
-<div class="outline-text-2" id="text-org20a85fc">
-</div></section>
-<section id="slide-orgc167f8d">
-<h3 id="orgc167f8d">Inside Out vs Outside In</h3>
-</section>
-<section id="slide-org34cbdca">
-<h3 id="org34cbdca">The power of relationships to fan our internal flame.</h3>
+<section id="slide-org8c8708b">
+<h4 id="org8c8708b">Space Repetition etc.</h4>
 </section>
 </section>
 <section>
-<section id="slide-org3dd8c48">
-<h2 id="org3dd8c48">How are learning and adaptability related?</h2>
-<div class="outline-text-2" id="text-org3dd8c48">
+<section id="slide-orgff7262e">
+<h2 id="orgff7262e">What is the difference between Learning and Education</h2>
+<div class="outline-text-2" id="text-orgff7262e">
 </div></section>
-<section id="slide-org9285ba9">
-<h3 id="org9285ba9">Learning is an expression of our adaptability.</h3>
-<div class="outline-text-3" id="text-org9285ba9">
-</div></section>
-<section id="slide-orgdc10d31">
-<h4 id="orgdc10d31">From an evolutionary perspective, we are the very best learners in all of history.</h4>
+<section id="slide-org3228e63">
+<h3 id="org3228e63">Inside Out vs Outside In</h3>
 </section>
-<section id="slide-org248d532">
-<h4 id="org248d532">We are in the midst of a massive adaptation to the age of information.</h4>
-<div class="outline-text-4" id="text-org248d532">
-</div><ul class="org-ul"><li><a id="org27370f3"></a><span class="todo TODO">TODO</span> (formate quote) Clojure just happens to specialize the processing information!<br  /><p>
+<section id="slide-orga198414">
+<h3 id="orga198414">The power of relationships to fan our internal flame.</h3>
+</section>
+</section>
+<section>
+<section id="slide-org13ad78e">
+<h2 id="org13ad78e">How are learning and adaptability related?</h2>
+<div class="outline-text-2" id="text-org13ad78e">
+</div></section>
+<section id="slide-org69f65cb">
+<h3 id="org69f65cb">Learning is an expression of our adaptability.</h3>
+<div class="outline-text-3" id="text-org69f65cb">
+</div></section>
+<section id="slide-orgff903d5">
+<h4 id="orgff903d5">From an evolutionary perspective, we are the very best learners in all of history.</h4>
+</section>
+<section id="slide-org54d4bf1">
+<h4 id="org54d4bf1">We are in the midst of a massive adaptation to the age of information.</h4>
+<div class="outline-text-4" id="text-org54d4bf1">
+</div><ul class="org-ul"><li><a id="org82f525e"></a><span class="todo TODO">TODO</span> (formate quote) Clojure just happens to specialize the processing information!<br  /><p>
 "Clojure is a Swiss Army Knife of operations over data" &#x2013; Rich Hickey
 </p></li></ul>
 </section>
 </section>
 <section>
-<section id="slide-org1751270">
-<h2 id="org1751270">Are we getting it?</h2>
-<div class="outline-text-2" id="text-org1751270">
+<section id="slide-org668d5b7">
+<h2 id="org668d5b7">Are we getting it?</h2>
+<div class="outline-text-2" id="text-org668d5b7">
 </div></section>
-<section id="slide-org5334e8f">
-<h3 id="org5334e8f">How many objects are we juggling in our learning?</h3>
+<section id="slide-org5cbdf3e">
+<h3 id="org5cbdf3e">How many objects are we juggling in our learning?</h3>
 </section>
-<section id="slide-org06e28ec">
-<h3 id="org06e28ec"><a href="https://www.farnamstreetblog.com/2013/01/how-people-learn/">How People Learn</a> Empathy/Understanding of Expert that Learner doesn't possess rich mental model, or even capacity to organize rich mental model immediately. This is grown over time by ensuring that fundamental concepts are well understood. This should be the main objective, rather than conveying a deluge of facts, which have no meaningful place in the mind to be stored effectively.</h3>
-<div class="outline-text-3" id="text-org06e28ec">
+<section id="slide-org14d2ac3">
+<h3 id="org14d2ac3"><a href="https://www.farnamstreetblog.com/2013/01/how-people-learn/">How People Learn</a> Empathy/Understanding of Expert that Learner doesn't possess rich mental model, or even capacity to organize rich mental model immediately. This is grown over time by ensuring that fundamental concepts are well understood. This should be the main objective, rather than conveying a deluge of facts, which have no meaningful place in the mind to be stored effectively.</h3>
+<div class="outline-text-3" id="text-org14d2ac3">
 </div></section>
-<section id="slide-org706119d">
-<h4 id="org706119d">Bite-size definitions for reading fluency and verbose, technically correct definitions for accurate understanding.</h4>
+<section id="slide-org0f9c1be">
+<h4 id="org0f9c1be">Bite-size definitions for reading fluency and verbose, technically correct definitions for accurate understanding.</h4>
 </section>
-<section id="slide-org926717b">
-<h3 id="org926717b">Examining the "genius programmer" image to foster welcoming culture, while still valuing competency, ingenuity &amp; creativity.</h3>
-<div class="outline-text-3" id="text-org926717b">
+<section id="slide-org8cfa13a">
+<h3 id="org8cfa13a">Examining the "genius programmer" image to foster welcoming culture, while still valuing competency, ingenuity &amp; creativity.</h3>
+<div class="outline-text-3" id="text-org8cfa13a">
 </div></section>
-<section id="slide-org4d7396e">
-<h4 id="org4d7396e">If we're really that smart we can make it better for others.</h4>
+<section id="slide-org0389d6a">
+<h4 id="org0389d6a">If we're really that smart we can make it better for others.</h4>
 </section>
-<section id="slide-org73efbba">
-<h4 id="org73efbba">Courage of honestly saying, "I'm not getting it". (Liberation from the weight of the expert mask)</h4>
-<div class="outline-text-4" id="text-org73efbba">
-</div><ul class="org-ul"><li><a id="org4c3fdb8"></a>Creates more accurate feedback loop.<br  /></li>
-<li><a id="orgdfe607a"></a><br  /></li></ul>
+<section id="slide-org50ec57f">
+<h4 id="org50ec57f">Courage of honestly saying, "I'm not getting it". (Liberation from the weight of the expert mask)</h4>
+<div class="outline-text-4" id="text-org50ec57f">
+</div><ul class="org-ul"><li><a id="org4ab70e2"></a>Creates more accurate feedback loop.<br  /></li>
+<li><a id="org3c49e05"></a><br  /></li></ul>
 </section>
 </section>
 <section>
-<section id="slide-orgd3b9b5c">
-<h2 id="orgd3b9b5c">My story: Hero to Zero</h2>
-<div class="outline-text-2" id="text-orgd3b9b5c">
+<section id="slide-org6047370">
+<h2 id="org6047370">My story: Hero to Zero</h2>
+<div class="outline-text-2" id="text-org6047370">
 </div></section>
-<section id="slide-orgfb06e88">
-<h3 id="orgfb06e88">How I found Clojure, How I'd like others to find Clojure</h3>
-<div class="outline-text-3" id="text-orgfb06e88">
+<section id="slide-orgb9f2a3b">
+<h3 id="orgb9f2a3b">How I found Clojure, How I'd like others to find Clojure</h3>
+<div class="outline-text-3" id="text-orgb9f2a3b">
 </div></section>
-<section id="slide-orgc8e94ac">
-<h4 id="orgc8e94ac">Clojure community leading the way technically- react</h4>
+<section id="slide-org02176e1">
+<h4 id="org02176e1">Clojure community leading the way technically- react</h4>
 </section>
-<section id="slide-org4324559">
-<h4 id="org4324559">Clojure could lead the way educationally too! This means people are suffering less before they find us.</h4>
+<section id="slide-org5fda66c">
+<h4 id="org5fda66c">Clojure could lead the way educationally too! This means people are suffering less before they find us.</h4>
 </section>
-<section id="slide-orgc4a0202">
-<h3 id="orgc4a0202">My view of the essence of the web: Communication</h3>
+<section id="slide-org71be512">
+<h3 id="org71be512">My view of the essence of the web: Communication</h3>
 </section>
 </section>
 <section>
-<section id="slide-org95d1815">
-<h2 id="org95d1815">Problems We're Trying Solve: Too much Struggle with Agenda, Not enough (or too much) with lessons!</h2>
-<div class="outline-text-2" id="text-org95d1815">
+<section id="slide-org1563e39">
+<h2 id="org1563e39">Problems We're Trying Solve: Too much Struggle with Agenda, Not enough (or too much) with lessons!</h2>
+<div class="outline-text-2" id="text-org1563e39">
 </div></section>
-<section id="slide-org477dc06">
-<h3 id="org477dc06">Richer, more personally customized learning paths (Agenda)</h3>
-<div class="outline-text-3" id="text-org477dc06">
+<section id="slide-org3563016">
+<h3 id="org3563016">Richer, more personally customized learning paths (Agenda)</h3>
+<div class="outline-text-3" id="text-org3563016">
 </div></section>
-<section id="slide-org6453076">
-<h4 id="org6453076">Open Data Format - Community maintained.</h4>
-<div class="outline-text-4" id="text-org6453076">
-</div><ul class="org-ul"><li><a id="orgb67553f"></a>Machine Readable Curricula (aka Curriculums, Learning Paths, Paths) with well-defined learning outcomes<br  /></li>
-<li><a id="org1935ad3"></a>Programming is like learning a tennis, highly technical takes years.<br  /><ul class="org-ul"><li><a id="org0533a9d"></a>'Start serving' is not helpful advice, so why do we persist with this advice.<br  /></li></ul></li></ul>
+<section id="slide-org9970c5b">
+<h4 id="org9970c5b">Open Data Format - Community maintained.</h4>
+<div class="outline-text-4" id="text-org9970c5b">
+</div><ul class="org-ul"><li><a id="orgbae12dd"></a>Machine Readable Curricula (aka Curriculums, Learning Paths, Paths) with well-defined learning outcomes<br  /></li>
+<li><a id="org85c425b"></a>Programming is like learning a tennis, highly technical takes years.<br  /><ul class="org-ul"><li><a id="org563eec8"></a>'Start serving' is not helpful advice, so why do we persist with this advice.<br  /></li></ul></li></ul>
 </section>
-<section id="slide-org955eaac">
-<h4 id="org955eaac">Conceptual Support from Teachers without spoonfeeding.</h4>
+<section id="slide-org6ace0b1">
+<h4 id="org6ace0b1">Conceptual Support from Teachers without spoonfeeding.</h4>
 </section>
 </section>
 <section>
-<section id="slide-orgae07410">
-<h2 id="orgae07410">Closing</h2>
-<div class="outline-text-2" id="text-orgae07410">
+<section id="slide-org04c1d60">
+<h2 id="org04c1d60">Closing</h2>
+<div class="outline-text-2" id="text-org04c1d60">
 </div></section>
-<section id="slide-orgc28dd4d">
-<h3 id="orgc28dd4d"></h3>
+<section id="slide-org17f7204">
+<h3 id="org17f7204"></h3>
 <blockquote nil>
 <p>
 Live as if you were to die tomorrow. Learn as if you were to live forever. &#x2013; Mahatma Gandhi
@@ -558,8 +573,8 @@ Live as if you were to die tomorrow. Learn as if you were to live forever. &#x20
 </section>
 </section>
 <section>
-<section id="slide-orgb36acbd">
-<h2 id="orgb36acbd">Quotes</h2>
+<section id="slide-orga121b8f">
+<h2 id="orga121b8f">Quotes</h2>
 <blockquote nil>
 <p>
 The work is quite feasible, and is the only thing in our power.…Let go of the past. We must only begin. Believe me and you will see. &#x2013;Epictetus
@@ -589,8 +604,8 @@ In mathematics the art of proposing a question must be held of higher value than
 </section>
 </section>
 <section>
-<section id="slide-org528be77">
-<h2 id="org528be77"><span class="todo TODO">TODO</span> Acknowledge existing culture of mentoring, learning, thinking, sharing, etc.</h2>
+<section id="slide-orgda4540c">
+<h2 id="orgda4540c"><span class="todo TODO">TODO</span> Acknowledge existing culture of mentoring, learning, thinking, sharing, etc.</h2>
 <p>
 -Hammock Driven Development by Rich Hickey
 -Eloquent Explanations by Russ Olsen
@@ -603,240 +618,240 @@ In mathematics the art of proposing a question must be held of higher value than
 </section>
 </section>
 <section>
-<section id="slide-org32dd37c">
-<h2 id="org32dd37c">Defining roles, eschewing roles: All people are communicators</h2>
-<div class="outline-text-2" id="text-org32dd37c">
+<section id="slide-org28410ef">
+<h2 id="org28410ef">Defining roles, eschewing roles: All people are communicators</h2>
+<div class="outline-text-2" id="text-org28410ef">
 </div></section>
-<section id="slide-orge400c9d">
-<h3 id="orge400c9d">Prosumption of Educational Materials, Mentorship etc.</h3>
+<section id="slide-org86f8436">
+<h3 id="org86f8436">Prosumption of Educational Materials, Mentorship etc.</h3>
 </section>
-<section id="slide-org3e880b1">
-<h3 id="org3e880b1">People are not machines! We are &#x2026;</h3>
+<section id="slide-org564493d">
+<h3 id="org564493d">People are not machines! We are &#x2026;</h3>
 </section>
-<section id="slide-org8da44d0">
-<h3 id="org8da44d0">Mentors are learners too.</h3>
+<section id="slide-orga0e4270">
+<h3 id="orga0e4270">Mentors are learners too.</h3>
 </section>
-<section id="slide-orgbf98ad9">
-<h3 id="orgbf98ad9">Embracing the life-long learning mentality without being distracted by every shiny new thing.</h3>
+<section id="slide-org45b8137">
+<h3 id="org45b8137">Embracing the life-long learning mentality without being distracted by every shiny new thing.</h3>
 </section>
 </section>
 <section>
-<section id="slide-org5d7299c">
-<h2 id="org5d7299c">Learning Methods</h2>
-<div class="outline-text-2" id="text-org5d7299c">
+<section id="slide-orga3f8279">
+<h2 id="orga3f8279">Learning Methods</h2>
+<div class="outline-text-2" id="text-orga3f8279">
 </div></section>
-<section id="slide-orge3dce77">
-<h3 id="orge3dce77">Project based learning vs theory &amp; lecture</h3>
+<section id="slide-orgd141d99">
+<h3 id="orgd141d99">Project based learning vs theory &amp; lecture</h3>
 </section>
-<section id="slide-org6cc9456">
-<h3 id="org6cc9456">When is helping hurting?</h3>
-<div class="outline-text-3" id="text-org6cc9456">
+<section id="slide-org8890cde">
+<h3 id="org8890cde">When is helping hurting?</h3>
+<div class="outline-text-3" id="text-org8890cde">
 </div></section>
-<section id="slide-org05e6e28">
-<h4 id="org05e6e28">Structured Struggle - Goldilocks learning.</h4>
+<section id="slide-org6c2d7b9">
+<h4 id="org6c2d7b9">Structured Struggle - Goldilocks learning.</h4>
 </section>
 </section>
 <section>
-<section id="slide-org85893b5">
-<h2 id="org85893b5">Learning Paths</h2>
-<div class="outline-text-2" id="text-org85893b5">
+<section id="slide-org90f3678">
+<h2 id="org90f3678">Learning Paths</h2>
+<div class="outline-text-2" id="text-org90f3678">
 </div></section>
-<section id="slide-org30ea3a8">
-<h3 id="org30ea3a8">Interstate vs back roads</h3>
+<section id="slide-org16c1b0c">
+<h3 id="org16c1b0c">Interstate vs back roads</h3>
 </section>
-<section id="slide-org2320f44">
-<h3 id="org2320f44">Machine Readable Curricula and Defined Learning Outcomes</h3>
-<div class="outline-text-3" id="text-org2320f44">
+<section id="slide-org14f15f4">
+<h3 id="org14f15f4">Machine Readable Curricula and Defined Learning Outcomes</h3>
+<div class="outline-text-3" id="text-org14f15f4">
 </div></section>
-<section id="slide-org97f3e0a">
-<h4 id="org97f3e0a">Degreed</h4>
+<section id="slide-org2be734b">
+<h4 id="org2be734b">Degreed</h4>
 </section>
-<section id="slide-org096e0f5">
-<h4 id="org096e0f5">Own your data.</h4>
+<section id="slide-orgfba94a0">
+<h4 id="orgfba94a0">Own your data.</h4>
 </section>
 </section>
 <section>
-<section id="slide-org78ad0e5">
-<h2 id="org78ad0e5">Student/Teacher Relationships (and Teacher Assistants)</h2>
-<div class="outline-text-2" id="text-org78ad0e5">
+<section id="slide-org3029177">
+<h2 id="org3029177">Student/Teacher Relationships (and Teacher Assistants)</h2>
+<div class="outline-text-2" id="text-org3029177">
 </div></section>
-<section id="slide-org74f29af">
-<h3 id="org74f29af">Formal education precedes deep mentorship, but not completely.</h3>
+<section id="slide-org4bb4e12">
+<h3 id="org4bb4e12">Formal education precedes deep mentorship, but not completely.</h3>
 </section>
 </section>
 <section>
-<section id="slide-org6eb6d2b">
-<h2 id="org6eb6d2b">Peer Groups (Student to Student)</h2>
-<div class="outline-text-2" id="text-org6eb6d2b">
+<section id="slide-orgc3b6839">
+<h2 id="orgc3b6839">Peer Groups (Student to Student)</h2>
+<div class="outline-text-2" id="text-orgc3b6839">
 </div></section>
-<section id="slide-org25dd368">
-<h3 id="org25dd368">Pair Programming and Study Groups</h3>
+<section id="slide-org6693094">
+<h3 id="org6693094">Pair Programming and Study Groups</h3>
 </section>
 </section>
 <section>
-<section id="slide-org7efbdc9">
-<h2 id="org7efbdc9">Apprenticeship/Mentor Relationships</h2>
-<div class="outline-text-2" id="text-org7efbdc9">
+<section id="slide-org194207e">
+<h2 id="org194207e">Apprenticeship/Mentor Relationships</h2>
+<div class="outline-text-2" id="text-org194207e">
 </div></section>
-<section id="slide-org80f36cd">
-<h3 id="org80f36cd">What are the wants, needs and aspirations of both apprentices and mentors?</h3>
-<div class="outline-text-3" id="text-org80f36cd">
+<section id="slide-orgb040b24">
+<h3 id="orgb040b24">What are the wants, needs and aspirations of both apprentices and mentors?</h3>
+<div class="outline-text-3" id="text-orgb040b24">
 </div></section>
-<section id="slide-org077ada4">
-<h4 id="org077ada4">Apprentices</h4>
-<div class="outline-text-4" id="text-org077ada4">
-</div><ul class="org-ul"><li><a id="orgc2dd685"></a>Structured Struggle vs Unstructured Struggle (Defeated Exasperation).<br  /></li>
-<li><a id="org79671aa"></a>(Source: <a href="https://www.farnamstreetblog.com/2013/01/how-people-learn/">How People Learn</a>) Empathy/Understanding of Mentor that Learner doesn't possess rich mental model, or even capacity to organize rich mental model immediately. This is grown over time by ensuring that fundamental concepts are well understood. This should be the main objective, rather than conveying a deluge of facts, which have no meaningful place in the mind to be stored effectively.<br  /></li></ul>
+<section id="slide-org44aabcb">
+<h4 id="org44aabcb">Apprentices</h4>
+<div class="outline-text-4" id="text-org44aabcb">
+</div><ul class="org-ul"><li><a id="org6e78079"></a>Structured Struggle vs Unstructured Struggle (Defeated Exasperation).<br  /></li>
+<li><a id="org45b4584"></a>(Source: <a href="https://www.farnamstreetblog.com/2013/01/how-people-learn/">How People Learn</a>) Empathy/Understanding of Mentor that Learner doesn't possess rich mental model, or even capacity to organize rich mental model immediately. This is grown over time by ensuring that fundamental concepts are well understood. This should be the main objective, rather than conveying a deluge of facts, which have no meaningful place in the mind to be stored effectively.<br  /></li></ul>
 </section>
-<section id="slide-org16e0bb1">
-<h4 id="org16e0bb1">Mentors</h4>
-<div class="outline-text-4" id="text-org16e0bb1">
-</div><ul class="org-ul"><li><a id="orge1a6978"></a>Support in achieving high impact community goals.<br  /><ul class="org-ul"><li><a id="org2e409b0"></a>Tutorials, Videos, Books, Lectures, Experiments<br  /></li>
-<li><a id="orga48addf"></a>Apprentice as Subject: One free of the 'Curse of Knowledge.'<br  /></li></ul></li></ul>
+<section id="slide-org0e7b34d">
+<h4 id="org0e7b34d">Mentors</h4>
+<div class="outline-text-4" id="text-org0e7b34d">
+</div><ul class="org-ul"><li><a id="org94a701b"></a>Support in achieving high impact community goals.<br  /><ul class="org-ul"><li><a id="org40cba50"></a>Tutorials, Videos, Books, Lectures, Experiments<br  /></li>
+<li><a id="org61ff643"></a>Apprentice as Subject: One free of the 'Curse of Knowledge.'<br  /></li></ul></li></ul>
 </section>
-<section id="slide-org8aa7c73">
-<h3 id="org8aa7c73">How do we improve the lives of individuals in each group?</h3>
-<div class="outline-text-3" id="text-org8aa7c73">
+<section id="slide-org4d038fe">
+<h3 id="org4d038fe">How do we improve the lives of individuals in each group?</h3>
+<div class="outline-text-3" id="text-org4d038fe">
 </div></section>
-<section id="slide-orgf256e3d">
-<h4 id="orgf256e3d">How can learners facilitate mentor's needs and wants?</h4>
+<section id="slide-orgde4143d">
+<h4 id="orgde4143d">How can learners facilitate mentor's needs and wants?</h4>
 </section>
-<section id="slide-org7b507bb">
-<h4 id="org7b507bb">How can mentors facilitate learner's needs and wants?</h4>
+<section id="slide-org206d8de">
+<h4 id="org206d8de">How can mentors facilitate learner's needs and wants?</h4>
 </section>
-<section id="slide-orgf1802eb">
-<h4 id="orgf1802eb">What tools, platforms and communication strategies exist or could exist to support these objectives?</h4>
+<section id="slide-org8fd174c">
+<h4 id="org8fd174c">What tools, platforms and communication strategies exist or could exist to support these objectives?</h4>
 </section>
 </section>
 <section>
-<section id="slide-orga599c39">
-<h2 id="orga599c39">New paradigms for collaboration?</h2>
-<div class="outline-text-2" id="text-orga599c39">
+<section id="slide-org09bcd2b">
+<h2 id="org09bcd2b">New paradigms for collaboration?</h2>
+<div class="outline-text-2" id="text-org09bcd2b">
 </div></section>
-<section id="slide-orgee708cb">
-<h3 id="orgee708cb">Education/Marketing Co-ops</h3>
-<div class="outline-text-3" id="text-orgee708cb">
+<section id="slide-org7245e1a">
+<h3 id="org7245e1a">Education/Marketing Co-ops</h3>
+<div class="outline-text-3" id="text-org7245e1a">
 </div></section>
-<section id="slide-org6683d2a">
-<h4 id="org6683d2a">nownetworking.com</h4>
-<div class="outline-text-4" id="text-org6683d2a">
-</div><ul class="org-ul"><li><a id="org327ec09"></a>Please take my idea, I'm to busy to do all of them!<br  /><ul class="org-ul"><li><a id="org93ee966"></a>Disclaimer: Okay, not all my ideas :)<br  /></li></ul></li></ul>
+<section id="slide-org4548325">
+<h4 id="org4548325">nownetworking.com</h4>
+<div class="outline-text-4" id="text-org4548325">
+</div><ul class="org-ul"><li><a id="orga50ef0e"></a>Please take my idea, I'm to busy to do all of them!<br  /><ul class="org-ul"><li><a id="orgf0a012f"></a>Disclaimer: Okay, not all my ideas :)<br  /></li></ul></li></ul>
 </section>
-<section id="slide-org5a2de4b">
-<h3 id="org5a2de4b">Open source &amp; Commerce in Harmony (Not highly relevant: save for another talk)</h3>
-<div class="outline-text-3" id="text-org5a2de4b">
+<section id="slide-org94b2264">
+<h3 id="org94b2264">Open source &amp; Commerce in Harmony (Not highly relevant: save for another talk)</h3>
+<div class="outline-text-3" id="text-org94b2264">
 </div></section>
-<section id="slide-org492405c">
-<h4 id="org492405c">Constructive Capitalism and the Long Wave</h4>
+<section id="slide-org5a5d5a8">
+<h4 id="org5a5d5a8">Constructive Capitalism and the Long Wave</h4>
 </section>
 </section>
 <section>
-<section id="slide-org263bb66">
-<h2 id="org263bb66">Innovations</h2>
-<div class="outline-text-2" id="text-org263bb66">
+<section id="slide-orgf1ef2c4">
+<h2 id="orgf1ef2c4">Innovations</h2>
+<div class="outline-text-2" id="text-orgf1ef2c4">
 </div></section>
-<section id="slide-orgb64ed54">
-<h3 id="orgb64ed54">Half-Screen Training</h3>
-<div class="outline-text-3" id="text-orgb64ed54">
+<section id="slide-org3f6eb6a">
+<h3 id="org3f6eb6a">Half-Screen Training</h3>
+<div class="outline-text-3" id="text-org3f6eb6a">
 </div></section>
-<section id="slide-orgdc3e013">
-<h4 id="orgdc3e013">Learning How to Learn</h4>
-<div class="outline-text-4" id="text-orgdc3e013">
-</div><ul class="org-ul"><li><a id="org3665550"></a>Focus Mode, In the Zone, Flow State<br  /><ul class="org-ul"><li><a id="org79e6998"></a><a href="https://www.ted.com/talks/mihaly_csikszentmihalyi_on_flow?language=en">https://www.ted.com/talks/mihaly_csikszentmihalyi_on_flow?language=en</a><br  /></li></ul></li></ul>
+<section id="slide-orge966e1f">
+<h4 id="orge966e1f">Learning How to Learn</h4>
+<div class="outline-text-4" id="text-orge966e1f">
+</div><ul class="org-ul"><li><a id="orgb4d0b67"></a>Focus Mode, In the Zone, Flow State<br  /><ul class="org-ul"><li><a id="org335fe82"></a><a href="https://www.ted.com/talks/mihaly_csikszentmihalyi_on_flow?language=en">https://www.ted.com/talks/mihaly_csikszentmihalyi_on_flow?language=en</a><br  /></li></ul></li></ul>
 </section>
-<section id="slide-org54fb7bf">
-<h3 id="org54fb7bf">Shell Steps</h3>
+<section id="slide-org25f9d4f">
+<h3 id="org25f9d4f">Shell Steps</h3>
 </section>
-<section id="slide-org3e84f5b">
-<h3 id="org3e84f5b">Now Networking</h3>
+<section id="slide-org886e784">
+<h3 id="org886e784">Now Networking</h3>
 </section>
-<section id="slide-org67e2679">
-<h3 id="org67e2679">Learning Paths</h3>
+<section id="slide-org68787c6">
+<h3 id="org68787c6">Learning Paths</h3>
 
 </section>
 </section>
 <section>
-<section id="slide-org1f003e9">
-<h2 id="org1f003e9">Complex sugar obscuring simple Clojure fundamentals (Whole other talk)</h2>
-<div class="outline-text-2" id="text-org1f003e9">
+<section id="slide-org3716da9">
+<h2 id="org3716da9">Complex sugar obscuring simple Clojure fundamentals (Whole other talk)</h2>
+<div class="outline-text-2" id="text-org3716da9">
 </div></section>
-<section id="slide-org3c1b402">
-<h3 id="org3c1b402">How do we best de-complect Clojure's complexities from its simple core?</h3>
-<div class="outline-text-3" id="text-org3c1b402">
+<section id="slide-org995f78d">
+<h3 id="org995f78d">How do we best de-complect Clojure's complexities from its simple core?</h3>
+<div class="outline-text-3" id="text-org995f78d">
 </div></section>
-<section id="slide-orgc8d8280">
-<h4 id="orgc8d8280">e.g. (Source: Russ Olsen) Russ helped me see that Namespaces were simply mappings of names to values but my learning of the subject was distracted by my instinct to tackle the complex aspects of Namespaces: symbols refer to vars, which refer to mutable storage locations, which contain values. These are too many incidental details to take on for a newcomer and distract from the fundamental simplicity of what Namespaces are about. It does, however, help to know that such incidental complexity has a purpose in Clojure, which is to keep unaware developers from shooting their toes off. This mentor related perspective helped me accept Clojure's complexity around Namespaces with more of an open mind, taking the sting out of it.</h4>
+<section id="slide-org7242faa">
+<h4 id="org7242faa">e.g. (Source: Russ Olsen) Russ helped me see that Namespaces were simply mappings of names to values but my learning of the subject was distracted by my instinct to tackle the complex aspects of Namespaces: symbols refer to vars, which refer to mutable storage locations, which contain values. These are too many incidental details to take on for a newcomer and distract from the fundamental simplicity of what Namespaces are about. It does, however, help to know that such incidental complexity has a purpose in Clojure, which is to keep unaware developers from shooting their toes off. This mentor related perspective helped me accept Clojure's complexity around Namespaces with more of an open mind, taking the sting out of it.</h4>
 </section>
 </section>
 <section>
-<section id="slide-orgdab6f2b">
-<h2 id="orgdab6f2b">Prior Art</h2>
-<div class="outline-text-2" id="text-orgdab6f2b">
+<section id="slide-org97279ed">
+<h2 id="org97279ed">Prior Art</h2>
+<div class="outline-text-2" id="text-org97279ed">
 </div></section>
-<section id="slide-orgf539b2e">
-<h3 id="orgf539b2e"><a href="http://lifehacker.com/top-10-ways-to-teach-yourself-to-code-1684250889A">http://lifehacker.com/top-10-ways-to-teach-yourself-to-code-1684250889A</a></h3>
+<section id="slide-orgce16f21">
+<h3 id="orgce16f21"><a href="http://lifehacker.com/top-10-ways-to-teach-yourself-to-code-1684250889A">http://lifehacker.com/top-10-ways-to-teach-yourself-to-code-1684250889A</a></h3>
 </section>
-<section id="slide-org027bea8">
-<h3 id="org027bea8"><a href="https://hackpledge.org/">https://hackpledge.org/</a></h3>
+<section id="slide-orgebd3847">
+<h3 id="orgebd3847"><a href="https://hackpledge.org/">https://hackpledge.org/</a></h3>
 </section>
 </section>
 <section>
-<section id="slide-orgce650e2">
-<h2 id="orgce650e2">Research</h2>
-<div class="outline-text-2" id="text-orgce650e2">
+<section id="slide-org45ab708">
+<h2 id="org45ab708">Research</h2>
+<div class="outline-text-2" id="text-org45ab708">
 </div></section>
-<section id="slide-org0c238d0">
-<h3 id="org0c238d0">Education: <a href="https://educarenow.wordpress.com/">https://educarenow.wordpress.com/</a></h3>
-<div class="outline-text-3" id="text-org0c238d0">
+<section id="slide-orge8f9689">
+<h3 id="orge8f9689">Education: <a href="https://educarenow.wordpress.com/">https://educarenow.wordpress.com/</a></h3>
+<div class="outline-text-3" id="text-orge8f9689">
 </div></section>
-<section id="slide-org25610c0">
-<h4 id="org25610c0">educare (latin): To draw out that which lies within.</h4>
+<section id="slide-orga2f84e0">
+<h4 id="orga2f84e0">educare (latin): To draw out that which lies within.</h4>
 </section>
-<section id="slide-orgf6aafcf">
-<h4 id="orgf6aafcf">Contrast ecurare definition to that of Education: The process of receiving or giving systematic instruction, especially at a school or university.</h4>
+<section id="slide-org508a37a">
+<h4 id="org508a37a">Contrast ecurare definition to that of Education: The process of receiving or giving systematic instruction, especially at a school or university.</h4>
 </section>
-<section id="slide-orgb97117b">
-<h3 id="orgb97117b">Adult Education <a href="https://en.wikipedia.org/wiki/Adult_education">https://en.wikipedia.org/wiki/Adult_education</a></h3>
-<div class="outline-text-3" id="text-orgb97117b">
+<section id="slide-org987d051">
+<h3 id="org987d051">Adult Education <a href="https://en.wikipedia.org/wiki/Adult_education">https://en.wikipedia.org/wiki/Adult_education</a></h3>
+<div class="outline-text-3" id="text-org987d051">
 </div></section>
-<section id="slide-orgde1c740">
-<h4 id="orgde1c740">Purpose: Vocational, Social, Recreational, Self-development: Ultimately to achieve human fulfillment</h4>
+<section id="slide-org4a3c828">
+<h4 id="org4a3c828">Purpose: Vocational, Social, Recreational, Self-development: Ultimately to achieve human fulfillment</h4>
 </section>
-<section id="slide-org924f24b">
-<h3 id="org924f24b">Is knowledge good? Am I really helping? <a href="http://super-memory.com/articles/goodness.htm">http://super-memory.com/articles/goodness.htm</a></h3>
+<section id="slide-orgeb5de8f">
+<h3 id="orgeb5de8f">Is knowledge good? Am I really helping? <a href="http://super-memory.com/articles/goodness.htm">http://super-memory.com/articles/goodness.htm</a></h3>
 </section>
-<section id="slide-orgc9c0a55">
-<h3 id="orgc9c0a55"><a href="https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/">https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/</a></h3>
+<section id="slide-org1451a34">
+<h3 id="org1451a34"><a href="https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/">https://www.brainpickings.org/2016/03/31/dostoyevsky-reason-emotion/</a></h3>
 
 </section>
 </section>
 <section>
-<section id="slide-orga8c5292">
-<h2 id="orga8c5292">Old Pitches</h2>
-<div class="outline-text-2" id="text-orga8c5292">
+<section id="slide-org5b46a42">
+<h2 id="org5b46a42">Old Pitches</h2>
+<div class="outline-text-2" id="text-org5b46a42">
 </div></section>
-<section id="slide-org0b4cc78">
-<h3 id="org0b4cc78">How can we best support the needs of Clojure learners? Imagine a future where a person interested in learning Clojure was presented with a menu of learning paths, each leading to well defined learning outcomes and offering various 'on-ramps' for learners of varying skill levels, especially, for learners completely new to programming. Imagine a future where every learner feels welcome and supported through supportive human relationships, from participation in users groups, educational co-ops, and especially one-on-one apprentice/mentor pairings. How can we place the needs of the learner above all else and grow Clojure to the scale of its full potential? Much progress has already been made, but what more can we do, together, to reach this goal?</h3>
+<section id="slide-orgd583736">
+<h3 id="orgd583736">How can we best support the needs of Clojure learners? Imagine a future where a person interested in learning Clojure was presented with a menu of learning paths, each leading to well defined learning outcomes and offering various 'on-ramps' for learners of varying skill levels, especially, for learners completely new to programming. Imagine a future where every learner feels welcome and supported through supportive human relationships, from participation in users groups, educational co-ops, and especially one-on-one apprentice/mentor pairings. How can we place the needs of the learner above all else and grow Clojure to the scale of its full potential? Much progress has already been made, but what more can we do, together, to reach this goal?</h3>
 </section>
-<section id="slide-org84b15d0">
-<h3 id="org84b15d0">A community-centered brainstorming session facilitated by vulnerably sharing my unconventional ideas about learning to program, and graciously inviting others to share their own. An experiment in group problem solving applied to the problem of learning 'Clojure'.</h3>
-<div class="outline-text-3" id="text-org84b15d0">
+<section id="slide-org7e432e9">
+<h3 id="org7e432e9">A community-centered brainstorming session facilitated by vulnerably sharing my unconventional ideas about learning to program, and graciously inviting others to share their own. An experiment in group problem solving applied to the problem of learning 'Clojure'.</h3>
+<div class="outline-text-3" id="text-org7e432e9">
 </div></section>
-<section id="slide-org44fd2d8">
-<h4 id="org44fd2d8">'Clojure' as used here is a heavily overloaded term, referring the body of knowledge encompassing Clojure(ish) technologies: ClojureScript, Datomic, React, React Native, bash/zshell, deployment technologies such as immutable infrastructure etc. etc. etc.</h4>
+<section id="slide-orgc76caa4">
+<h4 id="orgc76caa4">'Clojure' as used here is a heavily overloaded term, referring the body of knowledge encompassing Clojure(ish) technologies: ClojureScript, Datomic, React, React Native, bash/zshell, deployment technologies such as immutable infrastructure etc. etc. etc.</h4>
 </section>
-<section id="slide-org8bd8cde">
-<h3 id="org8bd8cde">I intend to foster an interactive conversation with my audience about how we can create stronger and more creative mentor/apprentice relationships in our growing community. The jumping off point would be my personal learning path of going from Hero to Zero. (Hero to Zero is a greatly overloaded term that is meaningful to me, but likely mysterious to others, so it will be a conversational thread wherein I can relay my personal experience of learning programming and Clojure.)</h3>
+<section id="slide-org3408718">
+<h3 id="org3408718">I intend to foster an interactive conversation with my audience about how we can create stronger and more creative mentor/apprentice relationships in our growing community. The jumping off point would be my personal learning path of going from Hero to Zero. (Hero to Zero is a greatly overloaded term that is meaningful to me, but likely mysterious to others, so it will be a conversational thread wherein I can relay my personal experience of learning programming and Clojure.)</h3>
 
 </section>
 </section>
 <section>
-<section id="slide-orga422795">
-<h2 id="orga422795">Why am I the person giving this talk?</h2>
-<div class="outline-text-2" id="text-orga422795">
+<section id="slide-org06485a6">
+<h2 id="org06485a6">Why am I the person giving this talk?</h2>
+<div class="outline-text-2" id="text-org06485a6">
 </div></section>
-<section id="slide-orgd4e0878">
-<h4 id="orgd4e0878"><span class="todo TODO">TODO</span> Long and documented history of putting my foot in my mouth</h4>
+<section id="slide-org6eff897">
+<h4 id="org6eff897"><span class="todo TODO">TODO</span> Long and documented history of putting my foot in my mouth</h4>
 <aside class="notes">
 <p>
 Much of the talk is about the human brain, and almost anything I say about the brain that fits into an hour long talk will be grossly over-simplified. 
@@ -844,8 +859,8 @@ Much of the talk is about the human brain, and almost anything I say about the b
 
 </aside>
 </section>
-<section id="slide-orga775fdd">
-<h4 id="orga775fdd"><span class="todo TODO">TODO</span> And thinking inside the box.</h4>
+<section id="slide-org8fd8030">
+<h4 id="org8fd8030"><span class="todo TODO">TODO</span> And thinking inside the box.</h4>
 <aside class="notes">
 <p>
 Learning is like breathing &#x2013; we're always doing it. My thoughts on learning are being articulated through a lifetime of inherited and accumulated personal biases, many, if not most of which, I am probably unaware. That's why I need your help to unlock the potential discoveries of this fledgling research.
@@ -853,8 +868,8 @@ Learning is like breathing &#x2013; we're always doing it. My thoughts on learni
 
 </aside>
 </section>
-<section id="slide-orge3fa058">
-<h4 id="orge3fa058">Seriously though!</h4>
+<section id="slide-org9b2cc20">
+<h4 id="org9b2cc20">Seriously though!</h4>
 <aside class="notes">
 <p>
 All joking aside, I'm deeply interested in this topic because learning to program, for me, has been a joy, but also a painful and lonely struggle. My experience and instincts tell that by the time most people discover Clojure, they've suffered needlessly for too long. I hope this talk can reach out and find aspiring learners at the outset of their learning journey. What can we do together to make learning Clojure a fantastic experience for everyone?
@@ -864,14 +879,14 @@ All joking aside, I'm deeply interested in this topic because learning to progra
 </section>
 </section>
 <section>
-<section id="slide-org1811106">
-<h2 id="org1811106">Could the keys to unlocking our human potential be hidden in the mysteries of the human brain?</h2>
-<div class="outline-text-2" id="text-org1811106">
+<section id="slide-org9e015cb">
+<h2 id="org9e015cb">Could the keys to unlocking our human potential be hidden in the mysteries of the human brain?</h2>
+<div class="outline-text-2" id="text-org9e015cb">
 </div></section>
-<section id="slide-org903ff91">
-<h4 id="org903ff91">Decide for yourself after we explore recent discoveries, including powerful new insights in motivation and procrastination.</h4>
-<div class="outline-text-4" id="text-org903ff91">
-</div><ul class="org-ul"><li><a id="org447c642"></a>How can science's new understanding of the placebo effect dramatically increase our chances of successfully mastering highly technical skills?<br  /><aside class="notes">
+<section id="slide-org44495ba">
+<h4 id="org44495ba">Decide for yourself after we explore recent discoveries, including powerful new insights in motivation and procrastination.</h4>
+<div class="outline-text-4" id="text-org44495ba">
+</div><ul class="org-ul"><li><a id="orgf926e90"></a>How can science's new understanding of the placebo effect dramatically increase our chances of successfully mastering highly technical skills?<br  /><aside class="notes">
 <p>
 That's just a taste of what we'll talk about in the next hour.
 </p>

--- a/notes.org
+++ b/notes.org
@@ -20,7 +20,15 @@
 note that I used two SPACES after the * to make the invisible heading for the non-title title slide.
 #+END_NOTES
 
-*
+#+BEGIN_NOTES
+aha! about the `PROPERTIES` below setting _all_ slide backgrounds vs. just this one:
+if the extra space in the *_ title/header1 is removed (which annoyingly happens automatically (autoformat?)
+then the value is extended to ALL slides, but if the second space remains and the '  ' is treated as the header title,
+then the custom background applies only to the slide.
+check that there's a litte dot instead of an asterisk...
+- autoformat is the culprit!  use SPC - t - W to disable auto-whitespace stripping
+#+END_NOTES
+* 
 :PROPERTIES:
 :reveal_background: file:resources/images/title-screen_2017-01-16_16-18-34.png
 :reveal_background_size: 100%


### PR DESCRIPTION
Just wanted to figure out the `PROPERTIES: background` issue.

If there's no content in an h1 value (`*`), org/reveal won't treat it as a header, which messes with the per-slide value of the `PROPERITIES:` beneath it, in this case the first slide. My spacemacs defaults to auto-strip-whitespace, which removed the spaces I had in there. Disable whitespace stripping with `SPC`-`t`-`W`.

The first slide should be the only one with the custom background now.